### PR TITLE
Handle NaN (Not a Number) in SF output with with multiple ids and identifiers

### DIFF
--- a/create_formatbarcodes.py
+++ b/create_formatbarcodes.py
@@ -3,7 +3,10 @@ import seaborn as sns
 import matplotlib.pyplot as plt
 import argparse
 import os
+import logging
 
+LOGFORMAT = '%(asctime)-15s %(levelname)s: %(message)s'
+DATEFORMAT = '%m/%d/%Y %H:%M:%S'
 
 def _make_parser():
 	parser = argparse.ArgumentParser()
@@ -25,18 +28,25 @@ def create_graphs(input_csv, output_dir, alpha = .2):
 	df.modified = pd.to_datetime(df.modified)
 	datemin = df.modified.min()
 	datemax = df.modified.max()
-
 	for format_id in df.id.unique():
 		ax = sns.scatterplot(x="modified", y="id", data=df[df.id == format_id], alpha = alpha, marker = '|')
 		ax.set_xlim(datemin, datemax)
 		ax.set_ylim
-		display_id = format_id.replace('/', '_')
+		try:
+			display_id = format_id.replace('/', '_')
+		except AttributeError:
+			logging.info(
+				"%s encountered while parsing CSV, loop will continue without",
+				format_id)
+			continue
 		ax.set(xlabel='Last Modified Date', ylabel='Format ID')
 		plt.savefig("{}.png".format(os.path.join(output_dir, display_id)))
 		plt.close()
-	    
+
 
 def main():
+	logging.basicConfig(format=LOGFORMAT, datefmt=DATEFORMAT, level="INFO")
+
 	parser = _make_parser()
 	args = parser.parse_args()
 

--- a/create_formatbarcodes.py
+++ b/create_formatbarcodes.py
@@ -57,6 +57,7 @@ def create_graphs(input_csv, output_dir, alpha=.2):
                 format_id)
             continue
         axis_.set(xlabel='Last Modified Date', ylabel='Format ID')
+        plt.tight_layout()
         plt.savefig("{}.png".format(os.path.join(output_dir, display_id)))
         plt.close()
 

--- a/create_formatbarcodes.py
+++ b/create_formatbarcodes.py
@@ -1,59 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""create_formatbarcodes.py
+
+Generate data-based distribution (barcode) charts for a given dataset. The
+identifier value sits on the y-axis and last-modified date on the x-axis.
+"""
+import argparse
+import logging
+import os
+
+import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
-import matplotlib.pyplot as plt
-import argparse
-import os
-import logging
 
 LOGFORMAT = '%(asctime)-15s %(levelname)s: %(message)s'
 DATEFORMAT = '%m/%d/%Y %H:%M:%S'
 
+
 def _make_parser():
-	parser = argparse.ArgumentParser()
-	parser.description = "Create format lifecycle graphs"
-	parser.add_argument("-i", "--input",
-	help = "path to anonymized collection format profile",
-	required = True)
-	parser.add_argument("-o", "--output",
-	help = "path to directory where to save lifecycle graphs",
-	required = True)
-	parser.add_argument("--alpha",
-	help = "how transparent should bars be, between 0 and 1",
-	default = .2)
-	return parser
+    """Create a parse for our command line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.description = "Create format lifecycle graphs"
+    parser.add_argument(
+        "-i", "--input",
+        help="path to anonymized collection format profile",
+        required=True)
+    parser.add_argument(
+        "-o", "--output",
+        help="path to directory where to save lifecycle graphs",
+        required=True)
+    parser.add_argument(
+        "--alpha",
+        help="how transparent should bars be, between 0 and 1",
+        default=.2)
+    return parser
 
 
-def create_graphs(input_csv, output_dir, alpha = .2):
-	df = pd.read_csv(input_csv)
-	df.modified = pd.to_datetime(df.modified)
-	datemin = df.modified.min()
-	datemax = df.modified.max()
-	for format_id in df.id.unique():
-		ax = sns.scatterplot(x="modified", y="id", data=df[df.id == format_id], alpha = alpha, marker = '|')
-		ax.set_xlim(datemin, datemax)
-		ax.set_ylim
-		try:
-			display_id = format_id.replace('/', '_')
-		except AttributeError:
-			logging.info(
-				"%s encountered while parsing CSV, loop will continue without",
-				format_id)
-			continue
-		ax.set(xlabel='Last Modified Date', ylabel='Format ID')
-		plt.savefig("{}.png".format(os.path.join(output_dir, display_id)))
-		plt.close()
+def create_graphs(input_csv, output_dir, alpha=.2):
+    """Generate graph output from the input data."""
+    data_frame = pd.read_csv(input_csv)
+    data_frame.modified = pd.to_datetime(data_frame.modified)
+    datemin = data_frame.modified.min()
+    datemax = data_frame.modified.max()
+    for format_id in data_frame.id.unique():
+        axis_ = sns.scatterplot(
+            x="modified", y="id", data=data_frame[data_frame.id == format_id],
+            alpha=alpha, marker='|')
+        axis_.set_xlim(datemin, datemax)
+        axis_.set_ylim()
+        try:
+            display_id = format_id.replace('/', '_')
+        except AttributeError:
+            logging.info(
+                "%s encountered while parsing CSV, loop will continue without",
+                format_id)
+            continue
+        axis_.set(xlabel='Last Modified Date', ylabel='Format ID')
+        plt.savefig("{}.png".format(os.path.join(output_dir, display_id)))
+        plt.close()
 
 
 def main():
-	logging.basicConfig(format=LOGFORMAT, datefmt=DATEFORMAT, level="INFO")
+    """Primary entry point for the script."""
+    logging.basicConfig(format=LOGFORMAT, datefmt=DATEFORMAT, level="INFO")
 
-	parser = _make_parser()
-	args = parser.parse_args()
+    parser = _make_parser()
+    args = parser.parse_args()
 
-	if os.path.exists(args.output):
-		create_graphs(args.input, args.output, args.alpha)
-	else:
-		raise Exception('Output directory does not exist.')
+    if os.path.exists(args.output):
+        create_graphs(args.input, args.output, args.alpha)
+    else:
+        raise Exception('Output directory does not exist.')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is split into three commits at present. 

1. Make sure NaN is handled in the plot output. An example where this is seen is using SF with multiple identifiers. PRONOM will be on one line, but not necessarily more than one so we end up with a blank field. 

2. A handful of Flake8 and Pylint changes. 

3. I noticed the x-axis label was being cropped, and Stack Overflow provided a nice one-line fix so I added it and it seems to work. 

I haven't been able to work on the plot output, or find a dataset that really emphasizes this technique your are exploring, but I have saved this plotting library which looks pretty cool and might provide an alternative to mathplotlib: https://plot.ly/python/