### PR TITLE
Format DROID column headers to be compatible with create barcode script

### DIFF
--- a/create_formatbarcodes.py
+++ b/create_formatbarcodes.py
@@ -3,7 +3,10 @@ import seaborn as sns
 import matplotlib.pyplot as plt
 import argparse
 import os
+import logging
 
+LOGFORMAT = '%(asctime)-15s %(levelname)s: %(message)s'
+DATEFORMAT = '%m/%d/%Y %H:%M:%S'
 
 def _make_parser():
 	parser = argparse.ArgumentParser()
@@ -25,18 +28,25 @@ def create_graphs(input_csv, output_dir, alpha = .2):
 	df.modified = pd.to_datetime(df.modified)
 	datemin = df.modified.min()
 	datemax = df.modified.max()
-
 	for format_id in df.id.unique():
 		ax = sns.scatterplot(x="modified", y="id", data=df[df.id == format_id], alpha = alpha, marker = '|')
 		ax.set_xlim(datemin, datemax)
 		ax.set_ylim
-		display_id = format_id.replace('/', '_')
+		try:
+			display_id = format_id.replace('/', '_')
+		except AttributeError:
+			logging.info(
+				"%s encountered while parsing CSV, loop will continue without",
+				format_id)
+			continue
 		ax.set(xlabel='Last Modified Date', ylabel='Format ID')
 		plt.savefig("{}.png".format(os.path.join(output_dir, display_id)))
 		plt.close()
-	    
+
 
 def main():
+	logging.basicConfig(format=LOGFORMAT, datefmt=DATEFORMAT, level="INFO")
+
 	parser = _make_parser()
 	args = parser.parse_args()
 

--- a/create_formatbarcodes.py
+++ b/create_formatbarcodes.py
@@ -57,6 +57,7 @@ def create_graphs(input_csv, output_dir, alpha=.2):
                 format_id)
             continue
         axis_.set(xlabel='Last Modified Date', ylabel='Format ID')
+        plt.tight_layout()
         plt.savefig("{}.png".format(os.path.join(output_dir, display_id)))
         plt.close()
 

--- a/create_formatbarcodes.py
+++ b/create_formatbarcodes.py
@@ -1,59 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""create_formatbarcodes.py
+
+Generate data-based distribution (barcode) charts for a given dataset. The
+identifier value sits on the y-axis and last-modified date on the x-axis.
+"""
+import argparse
+import logging
+import os
+
+import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
-import matplotlib.pyplot as plt
-import argparse
-import os
-import logging
 
 LOGFORMAT = '%(asctime)-15s %(levelname)s: %(message)s'
 DATEFORMAT = '%m/%d/%Y %H:%M:%S'
 
+
 def _make_parser():
-	parser = argparse.ArgumentParser()
-	parser.description = "Create format lifecycle graphs"
-	parser.add_argument("-i", "--input",
-	help = "path to anonymized collection format profile",
-	required = True)
-	parser.add_argument("-o", "--output",
-	help = "path to directory where to save lifecycle graphs",
-	required = True)
-	parser.add_argument("--alpha",
-	help = "how transparent should bars be, between 0 and 1",
-	default = .2)
-	return parser
+    """Create a parse for our command line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.description = "Create format lifecycle graphs"
+    parser.add_argument(
+        "-i", "--input",
+        help="path to anonymized collection format profile",
+        required=True)
+    parser.add_argument(
+        "-o", "--output",
+        help="path to directory where to save lifecycle graphs",
+        required=True)
+    parser.add_argument(
+        "--alpha",
+        help="how transparent should bars be, between 0 and 1",
+        default=.2)
+    return parser
 
 
-def create_graphs(input_csv, output_dir, alpha = .2):
-	df = pd.read_csv(input_csv)
-	df.modified = pd.to_datetime(df.modified)
-	datemin = df.modified.min()
-	datemax = df.modified.max()
-	for format_id in df.id.unique():
-		ax = sns.scatterplot(x="modified", y="id", data=df[df.id == format_id], alpha = alpha, marker = '|')
-		ax.set_xlim(datemin, datemax)
-		ax.set_ylim
-		try:
-			display_id = format_id.replace('/', '_')
-		except AttributeError:
-			logging.info(
-				"%s encountered while parsing CSV, loop will continue without",
-				format_id)
-			continue
-		ax.set(xlabel='Last Modified Date', ylabel='Format ID')
-		plt.savefig("{}.png".format(os.path.join(output_dir, display_id)))
-		plt.close()
+def create_graphs(input_csv, output_dir, alpha=.2):
+    """Generate graph output from the input data."""
+    data_frame = pd.read_csv(input_csv)
+    data_frame.modified = pd.to_datetime(data_frame.modified)
+    datemin = data_frame.modified.min()
+    datemax = data_frame.modified.max()
+    for format_id in data_frame.id.unique():
+        axis_ = sns.scatterplot(
+            x="modified", y="id", data=data_frame[data_frame.id == format_id],
+            alpha=alpha, marker='|')
+        axis_.set_xlim(datemin, datemax)
+        axis_.set_ylim()
+        try:
+            display_id = format_id.replace('/', '_')
+        except AttributeError:
+            logging.info(
+                "%s encountered while parsing CSV, loop will continue without",
+                format_id)
+            continue
+        axis_.set(xlabel='Last Modified Date', ylabel='Format ID')
+        plt.savefig("{}.png".format(os.path.join(output_dir, display_id)))
+        plt.close()
 
 
 def main():
-	logging.basicConfig(format=LOGFORMAT, datefmt=DATEFORMAT, level="INFO")
+    """Primary entry point for the script."""
+    logging.basicConfig(format=LOGFORMAT, datefmt=DATEFORMAT, level="INFO")
 
-	parser = _make_parser()
-	args = parser.parse_args()
+    parser = _make_parser()
+    args = parser.parse_args()
 
-	if os.path.exists(args.output):
-		create_graphs(args.input, args.output, args.alpha)
-	else:
-		raise Exception('Output directory does not exist.')
+    if os.path.exists(args.output):
+        create_graphs(args.input, args.output, args.alpha)
+    else:
+        raise Exception('Output directory does not exist.')
 
 
 if __name__ == "__main__":

--- a/parse_droid.py
+++ b/parse_droid.py
@@ -1,43 +1,60 @@
-import pandas as pd
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""parse_droid.py
+
+Anonymize and convert DROID csv to be compatible with
+create_formatbarcodes.py.
+"""
 import argparse
+
+import pandas as pd
 
 
 def _make_parser():
-	parser = argparse.ArgumentParser()
-	parser.description = "anonymize Droid csv output"
-	parser.add_argument("-i", "--input",
-		help = "path to Droid output csv",
-		required = True)
-	parser.add_argument("-o", "--output",
-		help = "path to anonymized output, default is input_cleaned.csv")
-	return parser
+    """Create a parse for our command line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.description = "anonymize Droid csv output"
+    parser.add_argument(
+        "-i", "--input",
+        help="path to Droid output csv",
+        required=True)
+    parser.add_argument(
+        "-o", "--output",
+        help="path to anonymized output, default is input_cleaned.csv")
+    return parser
 
 
 def clean_droid(input_csv, output_csv):
-	df = pd.read_csv(input_csv)
-	df = df[df.TYPE == 'File']
-	df['warning'] = df['EXTENSION_MISMATCH'].map({True: 'extension mismatch'})
-	df.drop(['ID', 'PARENT_ID', 'URI', 'FILE_PATH', 'NAME', 'METHOD',
-		'STATUS', 'TYPE', 'HASH', 'FORMAT_COUNT', 'MIME_TYPE', 'FORMAT_NAME',
-		'FORMAT_VERSION', 'EXTENSION_MISMATCH'], axis = 1, inplace = True)
-	# Rename fields to be consistent with the Siegfried Format
-	df = df.rename(columns={
-		'SIZE': 'filesize', 'PUID': 'id', 'LAST_MODIFIED': 'modified',
+    """Anonymize and format the input provided."""
+    data_field = pd.read_csv(input_csv)
+    data_field = data_field[data_field.TYPE == 'File']
+    data_field['warning'] = data_field['EXTENSION_MISMATCH']\
+        .map({True: 'extension mismatch'})
+    data_field.drop(['ID', 'PARENT_ID', 'URI', 'FILE_PATH', 'NAME', 'METHOD',
+                     'STATUS', 'TYPE', 'HASH', 'FORMAT_COUNT', 'MIME_TYPE',
+                     'FORMAT_NAME', 'FORMAT_VERSION', 'EXTENSION_MISMATCH'],
+                    axis=1, inplace=True)
+    # Rename fields to be consistent with the Siegfried Format
+    data_field = data_field.rename(columns={
+        'SIZE': 'filesize', 'PUID': 'id', 'LAST_MODIFIED': 'modified',
         'EXT': 'ext'})
-	df = df.sample(frac=1).reset_index(drop=True)
-	df.to_csv(output_csv, index = False)
+    data_field = data_field.sample(frac=1).reset_index(drop=True)
+    data_field.to_csv(output_csv, index=False)
+
 
 def main():
-	parser = _make_parser()
-	args = parser.parse_args()
+    """Generate graph output from the input data."""
+    parser = _make_parser()
+    args = parser.parse_args()
 
-	if args.output:
-		output_csv = args.output
-	else:
-		output_csv = args.input.replace('.', '_cleaned.')
+    if args.output:
+        output_csv = args.output
+    else:
+        output_csv = args.input.replace('.', '_cleaned.')
 
-	clean_droid(args.input, output_csv)
-	print('CSV cleaned and stored at {}'.format(output_csv))
+    clean_droid(args.input, output_csv)
+    print('CSV cleaned and stored at {}'.format(output_csv))
 
 
 if __name__ == "__main__":

--- a/parse_droid.py
+++ b/parse_droid.py
@@ -17,9 +17,13 @@ def clean_droid(input_csv, output_csv):
 	df = pd.read_csv(input_csv)
 	df = df[df.TYPE == 'File']
 	df['warning'] = df['EXTENSION_MISMATCH'].map({True: 'extension mismatch'})
-	df.drop(['ID', 'PARENT_ID', 'URI', 'FILE_PATH', 'NAME', 'METHOD', 
-		'STATUS', 'TYPE', 'HASH', 'FORMAT_COUNT', 'MIME_TYPE', 'FORMAT_NAME', 
+	df.drop(['ID', 'PARENT_ID', 'URI', 'FILE_PATH', 'NAME', 'METHOD',
+		'STATUS', 'TYPE', 'HASH', 'FORMAT_COUNT', 'MIME_TYPE', 'FORMAT_NAME',
 		'FORMAT_VERSION', 'EXTENSION_MISMATCH'], axis = 1, inplace = True)
+	# Rename fields to be consistent with the Siegfried Format
+	df = df.rename(columns={
+		'SIZE': 'filesize', 'PUID': 'id', 'LAST_MODIFIED': 'modified',
+        'EXT': 'ext'})
 	df = df.sample(frac=1).reset_index(drop=True)
 	df.to_csv(output_csv, index = False)
 


### PR DESCRIPTION
This PR brings the parse_droid script into line with the output of parse_siegfried. The use of the 'id' field opens up the opportunity to use arbitrary identifiers when creating barcodes. 